### PR TITLE
make config panel permissions work and install works on armhf

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -304,9 +304,9 @@ bridge:
     #   domain - All users on that homeserver
     #     mxid - Specific user
     permissions:
-        '__LISTRELAY__': relay
-        '__LISTUSER__': user
-        '__LISTADMIN__': admin
+        "*": "relay"
+        "example.com": "user"
+        "@admin:example.com": "admin"
 
     relay:
         # Whether relay mode should be allowed. If allowed, `!signal set-relay` can be used to turn any


### PR DESCRIPTION
## Problem

- getter setter does not work for permissions

## Solution

- use sed to make getter setter works
Additionaly i made a modification to make install, upgrade, restore works on armhf armel

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

